### PR TITLE
Improve packaging relative to loggregator

### DIFF
--- a/packages/dea_logging_agent/packaging
+++ b/packages/dea_logging_agent/packaging
@@ -2,7 +2,7 @@ set -e -x
 
 export GOROOT=$(readlink -nf /var/vcap/packages/golang1.7)
 export PATH=$GOROOT/bin:$PATH
-export GOPATH=$PWD/loggregator
+export GOPATH=$PWD/loggregator/src/dea_logging_agent
 
 go install deaagent/deaagent
-cp -a $PWD/loggregator/bin/deaagent ${BOSH_INSTALL_TARGET}
+cp -a $PWD/loggregator/src/dea_logging_agent/bin/deaagent ${BOSH_INSTALL_TARGET}

--- a/packages/dea_logging_agent/spec
+++ b/packages/dea_logging_agent/spec
@@ -3,31 +3,31 @@ name: dea_logging_agent
 dependencies:
 - golang1.7
 files:
-- loggregator/src/deaagent/LICENSE
-- loggregator/src/deaagent/NOTICE
-- loggregator/src/deaagent/*.go # gosub
-- loggregator/src/deaagent/deaagent/*.go # gosub
-- loggregator/src/deaagent/domain/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/dropsonde/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/dropsonde/emitter/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/dropsonde/envelope_sender/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/dropsonde/envelopes/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/dropsonde/factories/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/dropsonde/instrumented_handler/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/dropsonde/instrumented_round_tripper/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/dropsonde/log_sender/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/dropsonde/logs/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/dropsonde/metric_sender/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/dropsonde/metricbatcher/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/dropsonde/metrics/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/dropsonde/runtime_stats/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/gosteno/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/gosteno/syslog/*.go # gosub
-- loggregator/src/github.com/cloudfoundry/sonde-go/events/*.go # gosub
-- loggregator/src/github.com/gogo/protobuf/gogoproto/*.go # gosub
-- loggregator/src/github.com/gogo/protobuf/proto/*.go # gosub
-- loggregator/src/github.com/gogo/protobuf/protoc-gen-gogo/descriptor/*.go # gosub
-- loggregator/src/github.com/howeyc/fsnotify/*.go # gosub
-- loggregator/src/github.com/nu7hatch/gouuid/*.go # gosub
-- loggregator/src/logger/*.go # gosub
-- loggregator/src/signalmanager/*.go # gosub
+- loggregator/src/dea_logging_agent/src/deaagent/LICENSE
+- loggregator/src/dea_logging_agent/src/deaagent/NOTICE
+- loggregator/src/dea_logging_agent/src/deaagent/*.go # gosub
+- loggregator/src/dea_logging_agent/src/deaagent/deaagent/*.go # gosub
+- loggregator/src/dea_logging_agent/src/deaagent/domain/*.go # gosub
+- loggregator/src/dea_logging_agent/src/logger/*.go # gosub
+- loggregator/src/dea_logging_agent/src/signalmanager/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/dropsonde/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/dropsonde/emitter/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/dropsonde/envelope_sender/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/dropsonde/envelopes/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/dropsonde/factories/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/dropsonde/instrumented_handler/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/dropsonde/instrumented_round_tripper/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/dropsonde/log_sender/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/dropsonde/logs/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/dropsonde/metric_sender/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/dropsonde/metricbatcher/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/dropsonde/metrics/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/dropsonde/runtime_stats/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/gosteno/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/gosteno/syslog/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/cloudfoundry/sonde-go/events/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/gogo/protobuf/gogoproto/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/gogo/protobuf/proto/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/gogo/protobuf/protoc-gen-gogo/descriptor/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/howeyc/fsnotify/*.go # gosub
+- loggregator/src/dea_logging_agent/src/github.com/nu7hatch/gouuid/*.go # gosub


### PR DESCRIPTION
Previously the `dea_logging_agent` packaging required a number of
symlinks within loggregator proper. This commit removes the need for
those symlinks inside loggregator and pulls in all necessary
dependencies from within `dea_logging_agent`.

Unfortunately, the `dea_logging_agent` is still subsumed within the
loggregator release and must refer to its source code files relative to
the loggregator root.

Note this PR goes hand-in-hand with the PR in Loggregator [here](https://github.com/cloudfoundry/loggregator/pull/207)

/cc @jasonkeene 